### PR TITLE
feat: implémentation SEO complet — meta, OG, JSON-LD, sitemap, robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://noekenfack.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://noekenfack.vercel.app/</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://noekenfack.vercel.app/experience</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://noekenfack.vercel.app/Projects</loc>
+    <lastmod>2026-05-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/components/SeoHead.tsx
+++ b/src/components/SeoHead.tsx
@@ -1,0 +1,44 @@
+import Head from "next/head";
+
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_BASE_URL ?? "https://noekenfack.vercel.app"
+).replace(/\/$/, "");
+
+const DEFAULT_OG_IMAGE = `${BASE_URL}/images/profileNK.png`;
+
+interface SeoHeadProps {
+  title: string;
+  description: string;
+  /** Route path — e.g. "/" or "/experience" */
+  canonical: string;
+  ogImage?: string;
+}
+
+export function SeoHead({ title, description, canonical, ogImage }: SeoHeadProps) {
+  const url = `${BASE_URL}${canonical}`;
+  const image = ogImage ?? DEFAULT_OG_IMAGE;
+
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} key="description" />
+      <meta name="robots" content="index, follow" key="robots" />
+      <link rel="canonical" href={url} key="canonical" />
+
+      {/* Open Graph */}
+      <meta property="og:title" content={title} key="og:title" />
+      <meta property="og:description" content={description} key="og:description" />
+      <meta property="og:type" content="website" key="og:type" />
+      <meta property="og:url" content={url} key="og:url" />
+      <meta property="og:image" content={image} key="og:image" />
+      <meta property="og:locale" content="fr_CA" key="og:locale" />
+      <meta property="og:site_name" content="Aurel Noé Kenfack" key="og:site_name" />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" key="twitter:card" />
+      <meta name="twitter:title" content={title} key="twitter:title" />
+      <meta name="twitter:description" content={description} key="twitter:description" />
+      <meta name="twitter:image" content={image} key="twitter:image" />
+    </Head>
+  );
+}

--- a/src/components/home/ProjectCard.tsx
+++ b/src/components/home/ProjectCard.tsx
@@ -59,7 +59,11 @@ export default function ProjectCard({ project }: ProjectCardProps) {
                   >
                     <Image
                       src={img}
-                      alt={`${project.title} - ${index}`}
+                      alt={
+                        index === 0
+                          ? `${project.title} — ${project.tags.slice(0, 4).join(", ")}`
+                          : `${project.title} — aperçu ${index + 1}`
+                      }
                       fill
                       sizes="(max-width: 768px) 100vw, 40vw"
                       className="object-cover transition-transform hover:scale-105"

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -4,6 +4,7 @@ import { Navbar } from "@/components/layout/Navbar";
 import projects from "@/datas/projects.json";
 import { motion } from "framer-motion";
 import { useState } from "react";
+import { SeoHead } from "@/components/SeoHead";
 
 type Category = "all" | "development" | "academic" | "design";
 
@@ -35,6 +36,11 @@ const Projects = () => {
 
   return (
     <>
+      <SeoHead
+        title="Projets | Applications web et mobile"
+        description="Découvrez mes projets en développement web et mobile : React, Next.js, Node.js, microservices et design UX."
+        canonical="/Projects"
+      />
       <Navbar cvUrl={staticCvUrl} />
       <section id="projects" className="py-16 md:py-24 bg-accent/20">
         <SectionAnimation>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,8 +2,15 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="fr">
       <Head>
+        <meta name="author" content="Aurel Noé Kenfack" />
+        <meta
+          name="keywords"
+          content="développeur fullstack Montréal, React, Node.js, TypeScript, développeur web Montréal"
+        />
+        <link rel="icon" href="/favicon.ico" />
+        <meta name="theme-color" content="#0f172a" />
       </Head>
       <body className="antialiased">
         <Main />

--- a/src/pages/experience.tsx
+++ b/src/pages/experience.tsx
@@ -1,4 +1,3 @@
-import Head from "next/head";
 import { Layout } from "@/components/layout/Layout";
 import { Formation } from "@/components/home/Formation";
 import { Badge } from "@/components/ui/badge";
@@ -6,19 +5,18 @@ import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
 import { Calendar, MapPin } from "lucide-react";
 import { experiences } from "@/datas/experiences";
+import { SeoHead } from "@/components/SeoHead";
 
 const staticCvUrl = "/docs/CV_Noe-Kenfack.pdf";
 
 export default function ExperiencePage() {
   return (
     <>
-      <Head>
-        <title>Expériences — Noé Kenfack</title>
-        <meta
-          name="description"
-          content="Parcours professionnel de Noé Kenfack — développeur fullstack web et mobile basé à Montréal."
-        />
-      </Head>
+      <SeoHead
+        title="Expérience | Développeur Fullstack à Montréal"
+        description="Expériences professionnelles en développement fullstack : React, Node.js, API REST, CI/CD, Docker, projets web et mobile."
+        canonical="/experience"
+      />
       <Layout cvUrl={staticCvUrl}>
         <section className="py-16 md:py-24">
           <div className="container px-4 md:px-6">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,34 +1,64 @@
-
 import Head from "next/head";
 import { Layout } from "@/components/layout/Layout";
 import { Hero } from "@/components/home/Hero";
 import { About } from "@/components/home/About";
 import { Skills } from "@/components/home/Skills";
-import { Projects } from "@/components/home/Projects";
 import { Contact } from "@/components/home/Contact";
 import { ProjectsCarousel } from "@/components/home/ProjectsCarousel";
 import { Experience } from "@/components/home/Experience";
 import { Formation } from "@/components/home/Formation";
+import { SeoHead } from "@/components/SeoHead";
 
-// CV URL can be hardcoded here if needed, e.g.
-// const staticCvUrl = "/path/to/your/cv.pdf"; 
-// or leave it undefined if you don't want the download button for now.
-const staticCvUrl = "/docs/CV_Noe-Kenfack.pdf"; 
+const staticCvUrl = "/docs/CV_Noe-Kenfack.pdf";
+
+const BASE_URL = (
+  process.env.NEXT_PUBLIC_BASE_URL ?? "https://noekenfack.vercel.app"
+).replace(/\/$/, "");
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Aurel Noé Kenfack",
+  jobTitle: "Développeur Fullstack",
+  url: `${BASE_URL}/`,
+  image: `${BASE_URL}/images/profileNK.png`,
+  email: "kenfackaurel1@gmail.com",
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Montréal",
+    addressRegion: "QC",
+    addressCountry: "Canada",
+  },
+  sameAs: [
+    "https://www.linkedin.com/in/aurel-noe-kenfack-b137b01a2/",
+    "https://github.com/NoeKen",
+  ],
+};
 
 export default function Home() {
   return (
     <>
+      <SeoHead
+        title="Développeur Fullstack à Montréal | React, Node.js, TypeScript"
+        description="Portfolio de Aurel Noé Kenfack, développeur fullstack à Montréal. Applications web et mobile, architecture backend, API REST et expérience utilisateur."
+        canonical="/"
+      />
       <Head>
-        <title>Noé Kenfack — Développeur Fullstack</title>
-        <meta
-          name="description"
-          content="Portfolio de Noé Kenfack — Développeur Fullstack Web & Mobile basé à Montréal. Node.js, TypeScript, React, Next.js, PostgreSQL."
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <link rel="icon" href="/favicon.ico" />
       </Head>
-      
+
       <Layout cvUrl={staticCvUrl}>
         <Hero />
+        <section className="pb-6">
+          <div className="container px-4 md:px-6 text-center">
+            <h2 className="text-sm md:text-base font-medium text-muted-foreground">
+              Développeur Fullstack à Montréal spécialisé en React, Node.js et TypeScript
+            </h2>
+          </div>
+        </section>
         <About />
         <Skills />
         <Experience />


### PR DESCRIPTION
- Nouveau composant SeoHead réutilisable (title, description, robots, canonical, Open Graph, Twitter Cards) avec key-based deduplication
- _document.tsx : lang=fr, author, keywords, favicon, theme-color
- index.tsx : SeoHead, structured data JSON-LD (Person schema), H2 SEO
- experience.tsx / Projects.tsx : SeoHead avec titres et URLs canoniques
- ProjectCard : alt text enrichi avec titre + stack technologique
- public/sitemap.xml et robots.txt